### PR TITLE
Fix wrong initial image size in IE11 (#10)

### DIFF
--- a/js/imageMapResizer.js
+++ b/js/imageMapResizer.js
@@ -31,12 +31,28 @@
         }
 
         function start(){
+            var displayedWidth = null,
+                displayedHeight = null;
+        		
             //WebKit asyncs image loading, so we have to catch the load event.
             sourceImage.onload = function sourceImageOnLoadF(){
-                if ((displayedImage.width !== sourceImage.width) || (displayedImage.height !== sourceImage.height)) {
+                displayedWidth = displayedImage.width;
+                displayedHeight = displayedImage.height;
+            	
+                if ((displayedWidth !== sourceImage.width) || (displayedHeight !== sourceImage.height)) {
                     resizeMap();
                 }
-            };
+            }
+            displayedImage.onload = function() {
+                /* If sourceImage.onload() already fired, but we see different
+                 * displayed dimensions now, trigger a new resize. This fixes a
+                 * problem in IE11 (see #10)
+                 */
+                if (displayedWidth != null && displayedWidth != displayedImage.width) {
+                    //console.log("Displayed image size changed after initial check");
+                    resizeMap();
+                }
+            }
             //Make copy of image, so we can get the actual size measurements
             sourceImage.src = displayedImage.src;
         }


### PR DESCRIPTION
This works around an IE11 issue where the initial image size is wrongly reported sometimes (thus the image map will be resized to the wrong dimensions). See issue #10 