### PR TITLE
Add main js reference to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/davidjbradshaw/image-map-resizer.git"
   },
   "github": "https://github.com/davidjbradshaw/image-map-resizer",
+  "main": "js/imageMapResizer.min.js",
   "dependencies": {},
   "devDependencies": {
     "grunt": "0.4.1",


### PR DESCRIPTION
This allows to require image-map-resizer directly