### PR TITLE
Feature multiple images (Issue #56)

### DIFF
--- a/js/imageMapResizer.js
+++ b/js/imageMapResizer.js
@@ -59,7 +59,9 @@
         }
 
         function addEventListeners(){
+            var image = get_image(); //get current visible image
             image.addEventListener('load',  resizeMap, false); //Detect late image loads in IE11
+
             window.addEventListener('focus',  resizeMap, false); //Cope with window being resized whilst on another tab
             window.addEventListener('resize', debounce,  false);
             window.addEventListener('readystatechange', resizeMap,  false);

--- a/js/imageMapResizer.js
+++ b/js/imageMapResizer.js
@@ -21,6 +21,7 @@
         }
 
         function resizeMap() {
+            var image = get_image();
             function resizeAreaTag(cachedAreaCoords,idx){
                 function scale(coord){
                     var dimension = ( 1 === (isWidth = 1-isWidth) ? 'width' : 'height' );
@@ -51,6 +52,7 @@
         }
 
         function start(){
+            var image = get_image();
             if ((image.width !== image.naturalWidth) || (image.height !== image.naturalHeight)) {
                 resizeMap();
             }

--- a/js/imageMapResizer.js
+++ b/js/imageMapResizer.js
@@ -9,6 +9,17 @@
 
     function scaleImageMap(){
 
+        function get_image() {
+            var imageList = document.querySelectorAll('img[usemap="#'+map.name+'"]');
+            var count = imageList.length;
+            for (var i = 0; i < count; i++){
+                var cImage = imageList[i].offsetParent;
+                if (typeof cImage != undefined && cImage) {
+                    return imageList[i];
+                }
+            }
+        }
+
         function resizeMap() {
             function resizeAreaTag(cachedAreaCoords,idx){
                 function scale(coord){

--- a/js/imageMapResizer.js
+++ b/js/imageMapResizer.js
@@ -71,7 +71,6 @@
         function setup(){
             areas                 = map.getElementsByTagName('area');
             cachedAreaCoordsArray = Array.prototype.map.call(areas, getCoords);
-            image                 = document.querySelector('img[usemap="#'+map.name+'"]');
             map._resize           = resizeMap; //Bind resize method to HTML map element
         }
 


### PR DESCRIPTION
This is in relation to Issue #56. 

This adds a new function to read the first current visible image for an image map. The visible image is calculated on every image resize. This is useful if you have multiple images and the images set `display:none` so it returns the correct value and dimensions.